### PR TITLE
Remove MSHTML Reference

### DIFF
--- a/SapphireBootWPF.csproj
+++ b/SapphireBootWPF.csproj
@@ -209,17 +209,6 @@
     <Resource Include="SettingsImg\btn_dots_i.png" />
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="MSHTML">
-      <Guid>{3050F1C5-98B5-11CF-BB82-00AA00BDCE0B}</Guid>
-      <VersionMajor>4</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="HTML\server.html" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
~~Windows10 no longer has MSHTML, and Sapphire doesn't need it~~
Biscuit Boy lied