### PR TITLE
Allow specifying a custom lobby port in external.Boot

### DIFF
--- a/BootClient.cs
+++ b/BootClient.cs
@@ -14,27 +14,33 @@ namespace SapphireBootWPF
 {
     public static class BootClient
     {
-        public static void StartClient(string sessionId, string serverLobbyAddress, string serverFrontierAddress)
+        public static void StartClient(string sessionId, string serverLobbyAddress, string serverFrontierAddress, int serverLobbyPort)
         {
             // TODO: Send the CORRECT version of the client?
             string args = string.Format(
                 "DEV.TestSID={0} DEV.UseSqPack=1 DEV.DataPathType=1 " +
-                "DEV.LobbyHost01={1} DEV.LobbyPort01=54994 " +
-                "DEV.LobbyHost02={1} DEV.LobbyPort02=54994 " +
-                "DEV.LobbyHost03={1} DEV.LobbyPort03=54994 " +
-                "DEV.LobbyHost04={1} DEV.LobbyPort04=54994 " +
-                "DEV.LobbyHost05={1} DEV.LobbyPort05=54994 " +
-                "DEV.LobbyHost06={1} DEV.LobbyPort06=54994 " +
-                "DEV.LobbyHost07={1} DEV.LobbyPort07=54994 " +
-                "DEV.LobbyHost08={1} DEV.LobbyPort08=54994 " +
-                "SYS.Region=3 language={2} version=1.0.0.0 DEV.MaxEntitledExpansionID={3} DEV.GMServerHost={4} {5}",
-                sessionId, serverLobbyAddress, Settings.Default.SavedLanguage, Settings.Default.ExpansionLevel, serverFrontierAddress, Settings.Default.LaunchParams);
+                "DEV.LobbyHost01={1} DEV.LobbyPort01={2} " +
+                "DEV.LobbyHost02={1} DEV.LobbyPort02={2} " +
+                "DEV.LobbyHost03={1} DEV.LobbyPort03={2} " +
+                "DEV.LobbyHost04={1} DEV.LobbyPort04={2} " +
+                "DEV.LobbyHost05={1} DEV.LobbyPort05={2} " +
+                "DEV.LobbyHost06={1} DEV.LobbyPort06={2} " +
+                "DEV.LobbyHost07={1} DEV.LobbyPort07={2} " +
+                "DEV.LobbyHost08={1} DEV.LobbyPort08={2} " +
+                "SYS.Region=3 language={3} version=1.0.0.0 DEV.MaxEntitledExpansionID={4} DEV.GMServerHost={5} {6}",
+                sessionId,
+                serverLobbyAddress,
+                serverLobbyPort,
+                Settings.Default.SavedLanguage,
+                Settings.Default.ExpansionLevel,
+                serverFrontierAddress,
+                Settings.Default.LaunchParams);
 
             var startInfo = new ProcessStartInfo
             {
                 Arguments = args,
                 WorkingDirectory = Path.GetDirectoryName( Settings.Default.ClientPath ),
-                FileName = Path.GetFileName( Settings.Default.ClientPath )
+                FileName = Path.GetFileName( Settings.Default.ClientPath ),
             };
 
             Process proc = Process.Start( startInfo );

--- a/WebScriptApi.cs
+++ b/WebScriptApi.cs
@@ -14,11 +14,11 @@ namespace SapphireBootWPF
             this.window = window;
         }
 
-        public void Boot( string sid, string serverLobbyAddress, string serverFrontierAddress )
+        public void Boot( string sid, string serverLobbyAddress, string serverFrontierAddress, int serverLobbyPort = 54994 )
         {
             try
             {
-                BootClient.StartClient( sid, serverLobbyAddress, serverFrontierAddress );
+                BootClient.StartClient( sid, serverLobbyAddress, serverFrontierAddress, serverLobbyPort );
                 if ( Properties.Settings.Default.CloseOnLaunch )
                 {
                     Process.GetCurrentProcess().Kill();


### PR DESCRIPTION
Currently the default 54994 port is used no matter the API configuration.